### PR TITLE
Fix iOS 13 conflict with new dismissing gesture

### DIFF
--- a/Examples/Swift/UberSignatureDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/Swift/UberSignatureDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Swift/SignatureDrawingViewController.swift
+++ b/Sources/Swift/SignatureDrawingViewController.swift
@@ -45,6 +45,11 @@ public class SignatureDrawingViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    public override func loadView() {
+        let signatureView = SignatureView()
+        view = signatureView
+    }
+    
     /// Returns an image of the signature (with a transparent background).
     public var fullSignatureImage: UIImage? {
         return model.fullSignatureImage
@@ -185,4 +190,16 @@ extension Set where Element == UITouch {
         
         return touch?.location(in: touch?.view)
     }
+}
+
+// Fix iOS 13 conflict with new dismissing gesture
+class SignatureView: UIView {
+    
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer is UIPanGestureRecognizer {
+            return false
+        }
+        return true
+    }
+    
 }


### PR DESCRIPTION
Fix the conflict with the new swipe down gesture to dismiss a controller when it is not presented in full screen.